### PR TITLE
Use semantic retriever as chain default

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -41,6 +41,7 @@ def main():
                     "retriever": get_vector_retriever(),
                 },
             ],
+            default_retriever=get_vector_retriever(),
         )
         st.session_state["chain"] = chain
         st.success(f"Loaded model {model_name}")

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from langchain.chains.router import MultiRetrievalQAChain
+from langchain_core.retrievers import BaseRetriever
+from langchain_community.chat_models import ChatOpenAI
+
+from app.llm import load_llm
+from app.database import get_meta_retriever
+
+
+class DummyRetriever(BaseRetriever):
+    def _get_relevant_documents(self, query: str, run_manager=None):
+        return []
+
+
+def test_chain_uses_default_retriever(monkeypatch):
+    dummy = DummyRetriever()
+    monkeypatch.setattr('app.database.get_vector_retriever', lambda: dummy)
+
+    llm = load_llm("sshleifer/tiny-gpt2")
+    chain = MultiRetrievalQAChain.from_retrievers(
+        llm=llm,
+        retriever_infos=[
+            {
+                "name": "metadata",
+                "description": "file metadata search",
+                "retriever": get_meta_retriever(),
+            },
+            {
+                "name": "semantic",
+                "description": "content chunk semantic search",
+                "retriever": dummy,
+            },
+        ],
+        default_retriever=dummy,
+    )
+
+    default_llm = chain.default_chain.combine_documents_chain.llm_chain.llm
+    assert default_llm is llm
+    assert not isinstance(default_llm, ChatOpenAI)

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -8,5 +8,5 @@ from app.llm import load_llm
 
 def test_load_llm_small_model():
     llm = load_llm("sshleifer/tiny-gpt2")
-    text = llm("Hello world")
+    text = llm.invoke("Hello world")
     assert isinstance(text, str)


### PR DESCRIPTION
## Summary
- specify a default retriever when building the RAG chain
- add a regression test to ensure the default chain uses the HF model
- call `invoke()` in HuggingFace model test to avoid deprecation warnings

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684dbd06d454832b98d082d787108378