### PR TITLE
Switch to ParentDocumentRetriever

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ It targets a default setup similar to a MacBook M4 Pro with 24 GB of
 RAM but can be configured for other environments.
 
 The UI is built with **Streamlit** and uses **LangChain** with a
-HuggingFace model for question answering. Retrieval combines metadata and
-semantic searches via `MultiRetrievalQAChain`. Data is stored in
+HuggingFace model for question answering. Retrieval links content chunks
+back to their source documents via `ParentDocumentRetriever`. Data is stored in
 **Meilisearch** using two indexes (configurable via environment
 variables):
 

--- a/app/app.py
+++ b/app/app.py
@@ -1,12 +1,11 @@
 import streamlit as st
 
-from langchain.chains.router import MultiRetrievalQAChain
+from langchain.chains import RetrievalQAWithSourcesChain
 
 from .config import settings
 from .database import (
     search_index,
-    get_meta_retriever,
-    get_vector_retriever,
+    get_parent_retriever,
 )
 from .llm import load_llm
 
@@ -27,21 +26,8 @@ def main():
 
     if st.sidebar.button("Load model"):
         llm = load_llm(model_name)
-        chain = MultiRetrievalQAChain.from_retrievers(
-            llm=llm,
-            retriever_infos=[
-                {
-                    "name": "metadata",
-                    "description": "file metadata search",
-                    "retriever": get_meta_retriever(),
-                },
-                {
-                    "name": "semantic",
-                    "description": "content chunk semantic search",
-                    "retriever": get_vector_retriever(),
-                },
-            ],
-            default_retriever=get_vector_retriever(),
+        chain = RetrievalQAWithSourcesChain.from_chain_type(
+            llm, retriever=get_parent_retriever()
         )
         st.session_state["chain"] = chain
         st.success(f"Loaded model {model_name}")

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -3,12 +3,11 @@ import sys
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from langchain.chains.router import MultiRetrievalQAChain
+from langchain.chains import RetrievalQAWithSourcesChain
 from langchain_core.retrievers import BaseRetriever
 from langchain_community.chat_models import ChatOpenAI
 
 from app.llm import load_llm
-from app.database import get_meta_retriever
 
 
 class DummyRetriever(BaseRetriever):
@@ -16,28 +15,12 @@ class DummyRetriever(BaseRetriever):
         return []
 
 
-def test_chain_uses_default_retriever(monkeypatch):
+def test_chain_uses_llm():
     dummy = DummyRetriever()
-    monkeypatch.setattr('app.database.get_vector_retriever', lambda: dummy)
 
     llm = load_llm("sshleifer/tiny-gpt2")
-    chain = MultiRetrievalQAChain.from_retrievers(
-        llm=llm,
-        retriever_infos=[
-            {
-                "name": "metadata",
-                "description": "file metadata search",
-                "retriever": get_meta_retriever(),
-            },
-            {
-                "name": "semantic",
-                "description": "content chunk semantic search",
-                "retriever": dummy,
-            },
-        ],
-        default_retriever=dummy,
-    )
+    chain = RetrievalQAWithSourcesChain.from_chain_type(llm, retriever=dummy)
 
-    default_llm = chain.default_chain.combine_documents_chain.llm_chain.llm
-    assert default_llm is llm
-    assert not isinstance(default_llm, ChatOpenAI)
+    chain_llm = chain.combine_documents_chain.llm_chain.llm
+    assert chain_llm is llm
+    assert not isinstance(chain_llm, ChatOpenAI)


### PR DESCRIPTION
## Summary
- use `ParentDocumentRetriever` in the application
- add `MeiliDocStore` and helper to build the parent retriever
- adjust tests for new chain setup
- update README to mention the new approach

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dde39f310832bbedc58d53bf63d21