### PR TITLE
Add canonical URL retriever

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -22,7 +22,9 @@ def format_sources(hits: list[dict]) -> str:
 def main():
     st.title("Home Index RAG")
     query = st.text_input("Ask a question:")
-    model_name = st.sidebar.text_input("HuggingFace model", value=settings.llm_model_name)
+    model_name = st.sidebar.text_input(
+        "HuggingFace model", value=settings.llm_model_name
+    )
 
     if st.sidebar.button("Load model"):
         llm = load_llm(model_name)

--- a/app/config.py
+++ b/app/config.py
@@ -1,5 +1,6 @@
 from pydantic_settings import BaseSettings
 
+
 class Settings(BaseSettings):
     llm_model_name: str = "mistralai/Mistral-7B-v0.1"
     embed_model_name: str = "sentence-transformers/all-MiniLM-L6-v2"
@@ -7,5 +8,7 @@ class Settings(BaseSettings):
     meili_api_key: str | None = None
     files_index: str = "files"
     file_chunks_index: str = "file_chunks"
+    files_domain: str = "http://localhost"
+
 
 settings = Settings()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,6 +9,8 @@ from app.config import Settings
 def test_env_override(monkeypatch):
     monkeypatch.setenv("LLM_MODEL_NAME", "test-model")
     monkeypatch.setenv("EMBED_MODEL_NAME", "test-embed")
+    monkeypatch.setenv("FILES_DOMAIN", "https://example.com")
     s = Settings()
     assert s.llm_model_name == "test-model"
     assert s.embed_model_name == "test-embed"
+    assert s.files_domain == "https://example.com"

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -3,15 +3,39 @@ import sys
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from app.database import get_meili_client, get_meta_retriever
+from app.database import (
+    get_meili_client,
+    get_meta_retriever,
+    CanonicalURLRetriever,
+)
+from langchain_core.documents import Document
+from langchain_core.retrievers import BaseRetriever
 
 
 def test_get_meili_client_instance():
     client = get_meili_client()
     assert client
-    assert hasattr(client, 'http')
+    assert hasattr(client, "http")
 
 
 def test_meta_retriever():
     retriever = get_meta_retriever()
     assert hasattr(retriever, "get_relevant_documents")
+
+
+class DummyRetriever(BaseRetriever):
+    def _get_relevant_documents(self, query: str, run_manager=None):
+        meta = {
+            "paths": {"a.txt": 1.0, "b.txt": 2.0},
+            "mtime": 2.0,
+        }
+        return [Document(page_content="", metadata=meta)]
+
+
+def test_canonical_retriever():
+    dummy = DummyRetriever()
+    wrapper = CanonicalURLRetriever(dummy, base_url="https://domain")
+    docs = wrapper.get_relevant_documents("q")
+    assert docs[0].metadata["url"].endswith("b.txt")
+    assert docs[0].metadata["paths"][0].startswith("https://domain")
+    assert isinstance(docs[0].metadata["mtime"], str)


### PR DESCRIPTION
## Summary
- support `FILES_DOMAIN` in the configuration
- normalize metadata to canonical URLs with `CanonicalURLRetriever`
- wrap parent document retriever with the canonical retriever
- test new configuration and retrieval behaviour
- fix timestamp conversion for canonical retriever
- use `url` metadata key and include weekday for modification times

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684de2bd0494832bbbf4cdd6d5c2b771