### PR TITLE
Add Streamlit renderer for chain sources

### DIFF
--- a/app/chain.py
+++ b/app/chain.py
@@ -13,5 +13,7 @@ def build_qa_chain(model: BaseChatModel | None = None) -> RetrievalQAWithSources
     """Return a `RetrievalQAWithSourcesChain` configured for the app."""
     llm = model or load_llm()
     retriever = get_parent_retriever()
-    return RetrievalQAWithSourcesChain.from_chain_type(llm, retriever=retriever)
+    return RetrievalQAWithSourcesChain.from_chain_type(
+        llm, retriever=retriever, return_source_documents=True
+    )
 


### PR DESCRIPTION
## Summary
- display RetrievalQA source documents with a new `render_source` function
- return source documents from the QA chain
- show the documents in `app.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e67bdd020832bb3f6b1526a81e69e