### PR TITLE
Improve LLM cache logic

### DIFF
--- a/app/llm.py
+++ b/app/llm.py
@@ -9,6 +9,7 @@ from langchain_core.language_models.fake import FakeListLLM
 from .config import settings
 
 _cached_llm = None
+_cached_model_name: str | None = None
 
 
 def load_llm(model_name: str | None = None) -> BaseChatModel:
@@ -18,11 +19,11 @@ def load_llm(model_name: str | None = None) -> BaseChatModel:
     Otherwise a small HuggingFace model is loaded via ``transformers`` for
     compatibility with the tests.
     """
-    global _cached_llm
-    if _cached_llm is not None and model_name == settings.llm_model_name:
-        return _cached_llm
-
+    global _cached_llm, _cached_model_name
     model_name = model_name or settings.llm_model_name
+
+    if _cached_llm is not None and model_name == _cached_model_name:
+        return _cached_llm
 
     if model_name.endswith(".gguf"):
         llm = ChatLlamaCpp(
@@ -50,4 +51,5 @@ def load_llm(model_name: str | None = None) -> BaseChatModel:
         llm = HuggingFacePipeline(pipeline=gen_pipeline)
 
     _cached_llm = llm
+    _cached_model_name = model_name
     return llm

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -3,6 +3,8 @@ import sys
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+from app import llm as llm_module
+from app.config import settings
 from app.llm import load_llm
 
 
@@ -10,3 +12,24 @@ def test_load_llm_small_model():
     llm = load_llm("sshleifer/tiny-gpt2")
     text = llm.invoke("Hello world")
     assert isinstance(text, str)
+
+
+def test_load_llm_cached_default(monkeypatch):
+    monkeypatch.setattr(llm_module, "_cached_llm", None, raising=False)
+    monkeypatch.setattr(llm_module, "_cached_model_name", None, raising=False)
+    monkeypatch.setattr(settings, "llm_model_name", "sshleifer/tiny-gpt2")
+
+    llm1 = load_llm()
+    llm2 = load_llm()
+
+    assert llm1 is llm2
+
+
+def test_load_llm_cached_same_model(monkeypatch):
+    monkeypatch.setattr(llm_module, "_cached_llm", None, raising=False)
+    monkeypatch.setattr(llm_module, "_cached_model_name", None, raising=False)
+
+    llm1 = load_llm("sshleifer/tiny-gpt2")
+    llm2 = load_llm("sshleifer/tiny-gpt2")
+
+    assert llm1 is llm2


### PR DESCRIPTION
## Summary
- track cached model name in `app.llm`
- normalise model name before cache check
- return cached instance when the requested model matches
- test new caching behaviour

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e6e7a2df4832bb2b16995815931e7