### PR TITLE
Fix render_source download link

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -37,12 +37,7 @@ def render_source(doc: Document, *, base_download_dir: str = "/downloads/") -> N
         st.markdown(f"[View full-size]({url})")
     else:
         label = url.split("/")[-1]
-        st.download_button(
-            label=f"Download {label}",
-            data=None,
-            file_name=label,
-            url=url,
-        )
+        st.markdown(f"[Download {label}]({url})")
 
 
 def main():


### PR DESCRIPTION
## Summary
- remove unsupported st.download_button call in `render_source`
- provide a simple markdown download link instead

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e704d021c832ba12f27651be72b34