### PR TITLE
Use geopy to implement _geocode

### DIFF
--- a/app/pipeline.py
+++ b/app/pipeline.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from datetime import datetime
 
+from geopy.geocoders import Nominatim
+
 from typing import Optional
 
 from langchain_core.prompts import ChatPromptTemplate
@@ -80,9 +82,21 @@ def _parse_date(value: str) -> float | tuple[float, float] | None:
     return None
 
 
+_geolocator: Nominatim | None = None
+
+
 def _geocode(name: str) -> tuple[float | None, float | None]:
-    """Dummy location lookup returning ``(lat, lon)`` or ``(None, None)``."""
-    return None, None
+    """Look up a location name and return ``(lat, lon)`` coordinates."""
+    global _geolocator
+    if _geolocator is None:
+        _geolocator = Nominatim(user_agent="home-index-rag-query")
+    try:
+        location = _geolocator.geocode(name)
+    except Exception:
+        return None, None
+    if location is None:
+        return None, None
+    return location.latitude, location.longitude
 
 
 SCHEMA = FileDocument.model_json_schema()

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,6 @@ pydantic
 pydantic-settings
 pytest
 timefhuman
+geopy
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch==2.2.2+cpu

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -5,7 +5,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from datetime import datetime
 import timefhuman.main as tfm
-from app.pipeline import _parse_date
+from app.pipeline import _parse_date, _geocode
 
 
 def test_parse_iso_date():
@@ -28,3 +28,31 @@ def test_parse_human_between(monkeypatch):
         datetime(2020, 1, 1).timestamp(),
         datetime(2020, 1, 31).timestamp(),
     )
+
+
+def test_geocode_success(monkeypatch):
+    class Dummy:
+        latitude = 1.23
+        longitude = 4.56
+
+    class DummyLocator:
+        def geocode(self, name):
+            return Dummy()
+
+    import app.pipeline as pipeline_module
+    monkeypatch.setattr(pipeline_module, "_geolocator", None, raising=False)
+    monkeypatch.setattr("app.pipeline.Nominatim", lambda user_agent: DummyLocator())
+    lat, lon = _geocode("somewhere")
+    assert lat == 1.23 and lon == 4.56
+
+
+def test_geocode_failure(monkeypatch):
+    class DummyLocator:
+        def geocode(self, name):
+            return None
+
+    import app.pipeline as pipeline_module
+    monkeypatch.setattr(pipeline_module, "_geolocator", None, raising=False)
+    monkeypatch.setattr("app.pipeline.Nominatim", lambda user_agent: DummyLocator())
+    lat, lon = _geocode("unknown")
+    assert lat is None and lon is None


### PR DESCRIPTION
## Summary
- implement a real `_geocode` function using geopy's Nominatim
- add geopy dependency
- test geocoding logic

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e7adae218832b8190bdebef29f096